### PR TITLE
Revert "[Firebase 11] Update binary target with  pre-release artifact"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,8 +30,8 @@ let package = Package(
     ),
     .binaryTarget(
       name: "absl",
-      url: "https://dl.google.com/firebase/ios/bin/abseil/2.2024011602.0/pre_rc0/absl.zip"
-      checksum: "d9aca2c36ff4e690f263348fb2f3b04fa4ec59719715a2b77f768b4f182b524f"
+      url: "https://dl.google.com/firebase/ios/bin/abseil/1.2024011601.1/rc0/absl.zip",
+      checksum: "04840af59fd63769e489342445058e2a79b8c77799207a209c3cb9bd82c6e771"
     )
   ]
 )


### PR DESCRIPTION
This reverts commit 4127f6efdf6ecb16d8ed5d7868c3995fd9fd394c.

Same as grpc. I didn't tag anything, but should get this out of main.